### PR TITLE
Add Docker Container Hardening with cap_drop technical note

### DIFF
--- a/content/2026-04-18-docker-container-hardening-cap-drop.md
+++ b/content/2026-04-18-docker-container-hardening-cap-drop.md
@@ -1,0 +1,46 @@
+---
+title: "Docker Compose ile Linux Yeteneklerini Sınırlandırma (cap_drop)"
+draft: false
+date: 2026-04-18
+tags:
+  - docker
+  - devops
+  - security
+---
+
+Kapsayıcılar (containers) varsayılan olarak root kullanıcısı ile çalışsa da, tam bir sanal makine gibi davranmadıkları için Linux Kernel yeteneklerinin (capabilities) yalnızca bir alt kümesini kullanırlar. Güvenlik sıkılaştırması (hardening) yaparken `cap_drop` kullanarak kapsayıcıların sahip olduğu bu varsayılan yetenekleri asgari düzeye indirmek en iyi uygulamadır.
+
+İşte Docker Compose ile en az ayrıcalık (least privilege) prensibini uygulamak için örnek bir kullanım:
+
+```yaml
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    # 1. Adım: Tüm yetenekleri kaldır
+    cap_drop:
+      - ALL
+    # 2. Adım: Sadece uygulamanın çalışması için gerekli olanları geri ekle
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
+      - NET_BIND_SERVICE
+    # Ekstra Güvenlik: Salt okunur dosya sistemi
+    read_only: true
+    # Konteynerın kendi kendini durdurmasını önlemek için tmpfs noktaları (nginx özelinde)
+    tmpfs:
+      - /var/cache/nginx
+      - /var/run
+```
+
+**Nasıl Test Edilir?**
+
+Kapsayıcı içindeki yetenekleri doğrulamak için `capsh` komutunu kullanabilirsiniz (içeride yüklü olması şartıyla):
+
+```bash
+docker exec -it <container_id> capsh --print
+```
+
+**Not:** Hangi yeteneklere (capabilities) ihtiyaç duyduğunuzu bulmak genellikle deneme yanılma gerektirir. `cap_drop: - ALL` uyguladıktan sonra logları takip edip uygulamanın hata verdiği yeteneği `cap_add` altına ekleyerek güvenliği en üst düzeye çıkarabilirsiniz.


### PR DESCRIPTION
This PR adds a short, technical "how-to" note under the `content` directory about cybersecurity and DevOps, specifically focusing on Linux Capability constraints (`cap_drop`) using Docker Compose. The note is in Turkish, follows the requested filename format `YYYY-MM-DD-konu-kisa-ozet.md`, and includes the mandatory YAML frontmatter. Only the newly created file was formatted with Prettier to ensure repository guidelines are met without polluting the commit with changes to existing files.

---
*PR created automatically by Jules for task [8155870039100288830](https://jules.google.com/task/8155870039100288830) started by @0xf61*