### PR TITLE
Add Docker Compose Secret Management guide

### DIFF
--- a/content/guide/docker-compose-secret-management.md
+++ b/content/guide/docker-compose-secret-management.md
@@ -1,0 +1,53 @@
+---
+title: "Docker Compose Secret Management"
+draft: false
+date: 2026-04-23
+tags:
+  - docker
+  - security
+  - devops
+---
+
+Using environment variables in `docker-compose.yml` can expose sensitive data in logs or container metadata. Docker Compose provides a built-in `secrets` mechanism to securely pass information.
+
+1. **Create the secret files on the host system**
+
+   Create plain text files containing the secrets. Do not commit these files to version control.
+
+   ```bash
+   echo "super_secret_password" > db_password.txt
+   echo "secret_api_token" > api_token.txt
+   ```
+
+2. **Define secrets in `docker-compose.yml`**
+
+   Add a top-level `secrets` block and map the secrets to your services.
+
+   ```yaml
+   version: "3.8"
+
+   services:
+     web:
+       image: my-web-app:latest
+       secrets:
+         - api_token
+       environment:
+         - API_TOKEN_FILE=/run/secrets/api_token
+
+     db:
+       image: postgres:15
+       secrets:
+         - db_password
+       environment:
+         - POSTGRES_PASSWORD_FILE=/run/secrets/db_password
+
+   secrets:
+     db_password:
+       file: ./db_password.txt
+     api_token:
+       file: ./api_token.txt
+   ```
+
+3. **Access secrets inside the container**
+
+   Secrets are mounted as read-only files at `/run/secrets/<secret_name>` by default. Applications or scripts must be configured to read the value from these files rather than reading environment variables directly. In the example above, `POSTGRES_PASSWORD_FILE` tells PostgreSQL to read the password from `/run/secrets/db_password`.


### PR DESCRIPTION
Adds a short how-to markdown note about Docker Compose secret management to the `content/guide` directory. Includes instructions on file creation, `docker-compose.yml` config, and accessing secrets inside the container. Follows standard repository conventions for `content` files.

---
*PR created automatically by Jules for task [11862105036180550229](https://jules.google.com/task/11862105036180550229) started by @0xf61*