### PR TITLE
docs: add SSH key authentication hardening guide

### DIFF
--- a/content/ssh-key-auth-hardening.md
+++ b/content/ssh-key-auth-hardening.md
@@ -1,0 +1,42 @@
+---
+title: "Secure SSH with Key-Based Authentication"
+draft: false
+date: 2026-04-24
+tags:
+  - ssh
+  - linux
+  - system-administration
+---
+
+To secure your SSH server, disable password authentication and rely exclusively on SSH keys. This prevents brute-force attacks against user passwords.
+
+1. Generate an SSH key pair on your client machine (if you don't have one):
+
+   ```bash
+   ssh-keygen -t ed25519 -C "your_email@example.com"
+   ```
+
+2. Copy the public key to your server:
+
+   ```bash
+   ssh-copy-id username@server_ip
+   ```
+
+3. Log into your server and edit the SSH daemon configuration file:
+
+   ```bash
+   sudo nano /etc/ssh/sshd_config
+   ```
+
+4. Modify the following directives to disable password authentication and enable public key authentication:
+
+   ```text
+   PasswordAuthentication no
+   PubkeyAuthentication yes
+   PermitRootLogin prohibit-password
+   ```
+
+5. Restart the SSH service to apply the changes:
+   ```bash
+   sudo systemctl restart sshd
+   ```


### PR DESCRIPTION
Adds a short, technical "how-to" markdown note to the `content/` directory about securing SSH through key-based authentication. This fulfills the request for a cybersecurity/sysadmin topic with step-by-step instructions and required YAML frontmatter formatting.

---
*PR created automatically by Jules for task [12606244474257740851](https://jules.google.com/task/12606244474257740851) started by @0xf61*