### PR TITLE
Add docker-compose-secrets-management note

### DIFF
--- a/content/docker-compose-secrets-management.md
+++ b/content/docker-compose-secrets-management.md
@@ -1,0 +1,45 @@
+---
+title: "Docker Compose Secret Management"
+draft: false
+date: 2025-05-12
+tags:
+  - docker
+  - devops
+  - security
+---
+
+Storing sensitive information like database passwords or API keys directly in `docker-compose.yml` as environment variables is a security risk. Docker Compose supports managing secrets securely by injecting them into containers at runtime via files.
+
+First, create a text file containing the secret, for example, `db_password.txt`:
+
+```bash
+echo "SuperSecretPassword123" > db_password.txt
+```
+
+Next, define the secret in your `docker-compose.yml` and grant services access to it:
+
+```yaml
+version: "3.8"
+
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_password
+
+secrets:
+  db_password:
+    file: ./db_password.txt
+```
+
+When the container starts, Docker automatically mounts the secret file to `/run/secrets/db_password` inside the container.
+
+Many official images (like PostgreSQL, MySQL, and WordPress) natively support reading secrets from files by appending `_FILE` to the environment variable name. If your application does not natively support this, you must read the file directly within your code:
+
+```python
+# Example in Python
+with open('/run/secrets/db_password', 'r') as file:
+    db_password = file.read().strip()
+```


### PR DESCRIPTION
Added a new markdown note on managing secrets in Docker Compose. The note follows the required format with correct YAML frontmatter, uses simple English to provide direct and practical information with code examples, and avoids introductory fluff. All verification (Prettier, type check, tests) have passed successfully.

---
*PR created automatically by Jules for task [8634818364806208948](https://jules.google.com/task/8634818364806208948) started by @0xf61*