### PR TITLE
Add technical note on Docker Compose Secrets

### DIFF
--- a/content/docker-compose-secrets.md
+++ b/content/docker-compose-secrets.md
@@ -1,0 +1,45 @@
+---
+title: "Managing Secrets in Docker Compose"
+draft: false
+date: 2025-05-18
+tags:
+  - docker
+  - devops
+  - security
+---
+
+Docker secrets allow you to safely manage sensitive data like passwords and API keys without hardcoding them in your configuration files.
+
+Here is how to use secrets in Docker Compose.
+
+1. Create a file to store your secret data.
+
+```bash
+echo "my_super_secret_password" > db_password.txt
+```
+
+2. Update your `docker-compose.yml` to define the secret and pass it to a service.
+
+```yaml
+version: "3.8"
+
+services:
+  database:
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_password
+
+secrets:
+  db_password:
+    file: ./db_password.txt
+```
+
+3. Start your services.
+
+```bash
+docker-compose up -d
+```
+
+The service will read the password securely from the `/run/secrets/db_password` file inside the container.


### PR DESCRIPTION
Added a new technical note `content/docker-compose-secrets.md` detailing how to use Docker Compose secrets safely. Formatted the file to match project standards.

---
*PR created automatically by Jules for task [13161103865737950441](https://jules.google.com/task/13161103865737950441) started by @0xf61*