### PR TITLE
Add UFW Firewall Configuration Note

### DIFF
--- a/content/guide/ufw-firewall-configuration.md
+++ b/content/guide/ufw-firewall-configuration.md
@@ -7,7 +7,7 @@ tags:
   - system-administration
 ---
 
-### 1. Check UFW Status
+## 1. Check UFW Status
 
 Ensure UFW is installed and check its current status.
 
@@ -15,7 +15,7 @@ Ensure UFW is installed and check its current status.
 sudo ufw status verbose
 ```
 
-### 2. Set Default Policies
+## 2. Set Default Policies
 
 Deny all incoming traffic and allow all outgoing traffic by default.
 
@@ -24,7 +24,7 @@ sudo ufw default deny incoming
 sudo ufw default allow outgoing
 ```
 
-### 3. Allow SSH Connections
+## 3. Allow SSH Connections
 
 Always allow SSH connections before enabling the firewall to prevent locking yourself out.
 
@@ -32,7 +32,7 @@ Always allow SSH connections before enabling the firewall to prevent locking you
 sudo ufw allow ssh
 ```
 
-### 4. Allow Specific Services
+## 4. Allow Specific Services
 
 Allow HTTP and HTTPS traffic for web servers.
 
@@ -47,7 +47,7 @@ To allow a specific IP address to access a specific port:
 sudo ufw allow from 192.168.1.100 to any port 3306 proto tcp
 ```
 
-### 5. Enable the Firewall
+## 5. Enable the Firewall
 
 Apply the rules and enable UFW to start on boot.
 
@@ -55,7 +55,7 @@ Apply the rules and enable UFW to start on boot.
 sudo ufw enable
 ```
 
-### 6. Delete a Rule
+## 6. Delete a Rule
 
 To remove an existing rule, view the numbered rules:
 

--- a/content/ufw-firewall-configuration.md
+++ b/content/ufw-firewall-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "Basic UFW Firewall Configuration"
 draft: false
-date: 2025-05-22
+date: 2026-05-22
 tags:
   - security
   - system-administration
@@ -44,7 +44,7 @@ sudo ufw allow https
 To allow a specific IP address to access a specific port:
 
 ```bash
-sudo ufw allow from 192.168.1.100 to any port 3306
+sudo ufw allow from 192.168.1.100 to any port 3306 proto tcp
 ```
 
 ### 5. Enable the Firewall

--- a/content/ufw-firewall-configuration.md
+++ b/content/ufw-firewall-configuration.md
@@ -1,0 +1,70 @@
+---
+title: "Basic UFW Firewall Configuration"
+draft: false
+date: 2025-05-22
+tags:
+  - security
+  - system-administration
+---
+
+### 1. Check UFW Status
+
+Ensure UFW is installed and check its current status.
+
+```bash
+sudo ufw status verbose
+```
+
+### 2. Set Default Policies
+
+Deny all incoming traffic and allow all outgoing traffic by default.
+
+```bash
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+```
+
+### 3. Allow SSH Connections
+
+Always allow SSH connections before enabling the firewall to prevent locking yourself out.
+
+```bash
+sudo ufw allow ssh
+```
+
+### 4. Allow Specific Services
+
+Allow HTTP and HTTPS traffic for web servers.
+
+```bash
+sudo ufw allow http
+sudo ufw allow https
+```
+
+To allow a specific IP address to access a specific port:
+
+```bash
+sudo ufw allow from 192.168.1.100 to any port 3306
+```
+
+### 5. Enable the Firewall
+
+Apply the rules and enable UFW to start on boot.
+
+```bash
+sudo ufw enable
+```
+
+### 6. Delete a Rule
+
+To remove an existing rule, view the numbered rules:
+
+```bash
+sudo ufw status numbered
+```
+
+Then delete the rule by its number (e.g., rule 3):
+
+```bash
+sudo ufw delete 3
+```


### PR DESCRIPTION
Added a new technical how-to note on basic UFW firewall configuration to the `content` directory, following the required naming convention and YAML frontmatter. The content provides clear, direct, and step-by-step instructions for checking UFW status, setting default policies, and allowing/denying specific services, utilizing simple English and code examples.

---
*PR created automatically by Jules for task [17220075959185613649](https://jules.google.com/task/17220075959185613649) started by @0xf61*