### PR TITLE
Add new how-to note on Docker Compose secret management

### DIFF
--- a/content/docker-compose-secret-management.md
+++ b/content/docker-compose-secret-management.md
@@ -1,0 +1,38 @@
+---
+title: "Docker Compose Secret Management"
+draft: false
+date: 2025-05-26
+tags:
+  - docker
+  - devops
+  - security
+---
+
+To securely pass secrets to Docker containers without exposing them in environment variables or hardcoding them in `docker-compose.yml`, use Docker secrets.
+
+**1. Create a secret file**
+Create a text file containing your secret data (e.g., `db_password.txt`):
+
+```bash
+echo "SuperSecretPassword123!" > db_password.txt
+```
+
+**2. Define secrets in docker-compose.yml**
+Reference the file in the top-level `secrets` block and grant access to the specific service:
+
+```yaml
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_password
+
+secrets:
+  db_password:
+    file: ./db_password.txt
+```
+
+**3. Read the secret in your application**
+Docker mounts the secret file at `/run/secrets/<secret_name>` inside the container. Modify your application or entrypoint scripts to read the sensitive value directly from this file path instead of an environment variable.


### PR DESCRIPTION
Added a new technical how-to note in the `content` directory detailing step-by-step instructions for managing secrets securely using Docker Compose secrets, replacing environment variables. The file adheres to the required Markdown frontmatter and filename formatting rules. Tests and lint checks have been executed successfully.

---
*PR created automatically by Jules for task [8377027517298260927](https://jules.google.com/task/8377027517298260927) started by @0xf61*